### PR TITLE
fix: apply z-index for Safari overflow:hidden problem

### DIFF
--- a/src/lib/components/CircleWindow.scss
+++ b/src/lib/components/CircleWindow.scss
@@ -1,4 +1,5 @@
 .circleWindow {
+  z-index: 1;
   overflow: hidden;
   border: 8px solid white;
   border-radius: 100%;


### PR DESCRIPTION
In Safari, when transitioning, elements ignore `overflow: hidden` .
To avoid from this behavior, specify z-index for parent element.

https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
